### PR TITLE
docs: fix password source option typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ authelia-pam
   # This is the place from where authelia-pam reads the password.
   # Default 'stdin', but can be overriden when this program is used for something other than PAM.
   # For example, for [Home Assistant authentication provider] use '$password'. \
-  --password-srd 'stdin'
+  --password-src 'stdin'
   # Optional, if passed would print meta in [Home Assistant authentication provider] format to stdout on successful authentication
   --meta
 


### PR DESCRIPTION
Supersedes #16 by replaying the same README typo fix onto the current main branch, because the original fork branch cannot be updated by maintainers.

## Verification
- cargo check --all-targets --all-features
- cargo deny check
- cargo clippy --workspace --all-targets --all-features
- cargo test --all-features